### PR TITLE
feat: add Retail API rego tests and customer personas

### DIFF
--- a/.github/workflows/ea-deploy.yml
+++ b/.github/workflows/ea-deploy.yml
@@ -1,3 +1,5 @@
+# Deploys the Retail API system policies to EnforceAuth
+# Entity ID: 52bdc2ad-**** (configured in EA_ENTITY_ID secret)
 name: Deploy Policy Bundle
 
 on:
@@ -5,7 +7,8 @@ on:
   #push:
   #  branches: [develop]
   #  paths:
-  #    - 'policies/**'
+  #    - 'infra/opa/policies/**'
+  #    - 'projects/retail-api/**'
 
 permissions:
   id-token: write

--- a/.github/workflows/ea-deploy.yml
+++ b/.github/workflows/ea-deploy.yml
@@ -1,5 +1,5 @@
 # Deploys the Retail API system policies to EnforceAuth
-# Entity ID: 52bdc2ad-**** (configured in EA_ENTITY_ID secret)
+# Entity ID configured in EA_ENTITY_ID secret
 name: Deploy Policy Bundle
 
 on:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Banking application services and APIs:
 
 The CI workflow (`.github/workflows/ea-deploy.yml`) deploys the **Retail API** system policies to EnforceAuth:
 
-- **Entity ID**: `52bdc2ad-444f-4577-8459-62a69704eed5` (configured in `EA_ENTITY_ID` secret)
+- **Entity ID**: Configured in `EA_ENTITY_ID` secret
 - **Policies Location**: `infra/opa/policies/`
 - **Trigger**: Manual dispatch via `workflow_dispatch`
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,40 @@ Banking application services and APIs:
 - `consumer-accounts-internal-api/` - Account management service
 - Additional services as they are developed
 
+## CI/CD Pipeline
+
+### Policy Deployment
+
+The CI workflow (`.github/workflows/ea-deploy.yml`) deploys the **Retail API** system policies to EnforceAuth:
+
+- **Entity ID**: `52bdc2ad-444f-4577-8459-62a69704eed5` (configured in `EA_ENTITY_ID` secret)
+- **Policies Location**: `infra/opa/policies/`
+- **Trigger**: Manual dispatch via `workflow_dispatch`
+
+The workflow uses the EnforceAuth GitHub Action to deploy policy bundles with wait-for-completion and a 10-minute timeout.
+
 ## Quick Start
+
+### Running Rego Tests
+
+Run policy tests locally using `opa test` or `eopa test`:
+
+```bash
+# Run all policy tests
+opa test infra/opa/policies/ -v
+
+# Run only retail_api tests
+opa test infra/opa/policies/retail/retail_api/ -v
+
+# With eopa (Enterprise OPA)
+eopa test infra/opa/policies/ -v
+```
+
+Test files are located alongside policy files with `_test.rego` suffix:
+- `infra/opa/policies/retail/retail_api/authentication_test.rego`
+- `infra/opa/policies/retail/retail_api/accounts_test.rego`
+- `infra/opa/policies/retail/retail_api/compliance_test.rego`
+- `infra/opa/policies/retail/retail_api/transactions_test.rego`
 
 ### Testing Authorization Policies
 

--- a/infra/opa/data/users.json
+++ b/infra/opa/data/users.json
@@ -62,12 +62,87 @@
     },
     "slee": {
       "role": "analyst",
-      "permissions": ["accounts:read", "balance:read", "transactions:read", "terms:read"],
+      "permissions": [
+        "accounts:read",
+        "balance:read",
+        "transactions:read",
+        "terms:read"
+      ],
       "department": "analytics",
       "active": false,
       "token": "slee_token_000",
       "exp": 1793456391,
       "assigned_accounts": []
+    },
+    "alice.consumer": {
+      "role": "retail_customer",
+      "permissions": [
+        "accounts:read",
+        "balance:read",
+        "transactions:read",
+        "transactions:create",
+        "credit:create",
+        "debit:create",
+        "terms:read"
+      ],
+      "department": "retail_banking",
+      "active": true,
+      "token": "alice_consumer_token",
+      "exp": 1793456391,
+      "customer_tier": "standard",
+      "owned_accounts": ["ACC-R001", "ACC-R002"]
+    },
+    "bob.premium": {
+      "role": "retail_customer_premium",
+      "permissions": [
+        "accounts:read",
+        "balance:read",
+        "transactions:read",
+        "transactions:create",
+        "credit:create",
+        "debit:create",
+        "terms:read"
+      ],
+      "department": "retail_banking",
+      "active": true,
+      "token": "bob_premium_token",
+      "exp": 1793456391,
+      "customer_tier": "premium",
+      "owned_accounts": ["ACC-R003", "ACC-R004", "ACC-R005"]
+    },
+    "carol.joint": {
+      "role": "retail_customer",
+      "permissions": [
+        "accounts:read",
+        "balance:read",
+        "transactions:read",
+        "transactions:create",
+        "credit:create",
+        "debit:create",
+        "terms:read"
+      ],
+      "department": "retail_banking",
+      "active": true,
+      "token": "carol_joint_token",
+      "exp": 1793456391,
+      "customer_tier": "standard",
+      "owned_accounts": ["ACC-R006"],
+      "joint_accounts": ["ACC-R001"]
+    },
+    "dan.inactive": {
+      "role": "retail_customer",
+      "permissions": [
+        "accounts:read",
+        "balance:read",
+        "transactions:read",
+        "terms:read"
+      ],
+      "department": "retail_banking",
+      "active": false,
+      "token": "dan_inactive_token",
+      "exp": 1793456391,
+      "customer_tier": "standard",
+      "owned_accounts": ["ACC-R007"]
     }
   },
   "user_accounts": {
@@ -85,24 +160,52 @@
       "ACC010"
     ],
     "rbrown": ["ACC001", "ACC002", "ACC003"],
-    "slee": []
+    "slee": [],
+    "alice.consumer": ["ACC-R001", "ACC-R002"],
+    "bob.premium": ["ACC-R003", "ACC-R004", "ACC-R005"],
+    "carol.joint": ["ACC-R006", "ACC-R001"],
+    "dan.inactive": ["ACC-R007"]
   },
   "roles": {
     "manager": {
       "level": 4,
-      "description": "Full access to all banking operations and administrative functions"
+      "description": "Full access to all banking operations and administrative functions",
+      "type": "internal"
     },
     "senior_representative": {
       "level": 3,
-      "description": "Enhanced customer service representative with transaction privileges"
+      "description": "Enhanced customer service representative with transaction privileges",
+      "type": "internal"
     },
     "representative": {
       "level": 2,
-      "description": "Standard customer service representative with read access"
+      "description": "Standard customer service representative with read access",
+      "type": "internal"
     },
     "analyst": {
       "level": 1,
-      "description": "Analytics role with limited read-only access"
+      "description": "Analytics role with limited read-only access",
+      "type": "internal"
+    },
+    "retail_customer": {
+      "level": 1,
+      "description": "Standard retail banking customer with access to own accounts",
+      "type": "external",
+      "daily_limits": {
+        "atm_withdrawal": 500,
+        "debit_card": 2500,
+        "transfer": 5000
+      }
+    },
+    "retail_customer_premium": {
+      "level": 2,
+      "description": "Premium retail banking customer with higher limits and priority service",
+      "type": "external",
+      "daily_limits": {
+        "atm_withdrawal": 1000,
+        "debit_card": 10000,
+        "transfer": 25000
+      }
     }
   },
   "departments": {
@@ -126,6 +229,14 @@
         "start": 8,
         "end": 18
       }
+    },
+    "retail_banking": {
+      "access_level": "customer",
+      "business_hours": {
+        "start": 0,
+        "end": 24
+      },
+      "description": "External retail banking customers accessing their own accounts"
     }
   }
 }

--- a/infra/opa/data/users.json
+++ b/infra/opa/data/users.json
@@ -62,12 +62,7 @@
     },
     "slee": {
       "role": "analyst",
-      "permissions": [
-        "accounts:read",
-        "balance:read",
-        "transactions:read",
-        "terms:read"
-      ],
+      "permissions": ["accounts:read", "balance:read", "transactions:read", "terms:read"],
       "department": "analytics",
       "active": false,
       "token": "slee_token_000",
@@ -131,12 +126,7 @@
     },
     "dan.inactive": {
       "role": "retail_customer",
-      "permissions": [
-        "accounts:read",
-        "balance:read",
-        "transactions:read",
-        "terms:read"
-      ],
+      "permissions": ["accounts:read", "balance:read", "transactions:read", "terms:read"],
       "department": "retail_banking",
       "active": false,
       "token": "dan_inactive_token",

--- a/infra/opa/policies/retail/retail_api/accounts_test.rego
+++ b/infra/opa/policies/retail/retail_api/accounts_test.rego
@@ -1,0 +1,488 @@
+package retail.retail_api.accounts_test
+
+import rego.v1
+
+import data.retail.retail_api.accounts
+
+# Mock internal employee data for testing
+mock_users := {
+	"manager1": {
+		"token": "token-manager",
+		"role": "manager",
+		"permissions": ["accounts:read", "accounts:create", "accounts:delete", "accounts:update", "balance:read"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"senior_rep": {
+		"token": "token-senior",
+		"role": "senior_representative",
+		"permissions": ["accounts:read", "accounts:create", "accounts:update", "balance:read"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"rep1": {
+		"token": "token-rep",
+		"role": "representative",
+		"permissions": ["accounts:read", "balance:read"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"alice.consumer": {
+		"token": "token-alice",
+		"role": "retail_customer",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "transactions:create", "credit:create", "debit:create", "terms:read"],
+		"department": "retail_banking",
+		"active": true,
+		"exp": 9999999999,
+		"customer_tier": "standard",
+	},
+	"bob.premium": {
+		"token": "token-bob",
+		"role": "retail_customer_premium",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "transactions:create", "credit:create", "debit:create", "terms:read"],
+		"department": "retail_banking",
+		"active": true,
+		"exp": 9999999999,
+		"customer_tier": "premium",
+	},
+	"carol.joint": {
+		"token": "token-carol",
+		"role": "retail_customer",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "transactions:create", "credit:create", "debit:create", "terms:read"],
+		"department": "retail_banking",
+		"active": true,
+		"exp": 9999999999,
+		"customer_tier": "standard",
+	},
+	"dan.inactive": {
+		"token": "token-dan",
+		"role": "retail_customer",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "terms:read"],
+		"department": "retail_banking",
+		"active": false,
+		"exp": 9999999999,
+		"customer_tier": "standard",
+	},
+}
+
+# Mock user-account assignments (includes both employees and customers)
+mock_user_accounts := {
+	"rep1": ["ACC001", "ACC002"],
+	"senior_rep": ["ACC001", "ACC003"],
+	"alice.consumer": ["ACC-R001", "ACC-R002"],
+	"bob.premium": ["ACC-R003", "ACC-R004", "ACC-R005"],
+	"carol.joint": ["ACC-R006", "ACC-R001"],
+	"dan.inactive": ["ACC-R007"],
+}
+
+# Test: account_access_allowed for manager (can access any account)
+test_account_access_manager if {
+	accounts.account_access_allowed({"role": "manager"}, "ANY-ACCOUNT-ID")
+}
+
+# Test: account_access_allowed for user with assigned account
+test_account_access_assigned if {
+	accounts.account_access_allowed(
+		{"role": "representative", "sub": "rep1"},
+		"ACC001",
+	) with data.user_accounts as mock_user_accounts
+}
+
+# Test: account_access_allowed denied for unassigned account
+test_account_access_denied_unassigned if {
+	not accounts.account_access_allowed(
+		{"role": "representative", "sub": "rep1"},
+		"ACC999",
+	) with data.user_accounts as mock_user_accounts
+}
+
+# Test: extract_account_id from path
+test_extract_account_id if {
+	account_id := accounts.extract_account_id("/accounts/ACC123")
+	account_id == "ACC123"
+}
+
+# Test: extract_account_id from nested path
+test_extract_account_id_nested if {
+	account_id := accounts.extract_account_id("/accounts/ACC456/balance")
+	account_id == "ACC456"
+}
+
+# Test: allow_read_account for manager
+test_allow_read_account_manager if {
+	accounts.allow_read_account with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC123",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_read_account for rep with assigned account
+test_allow_read_account_assigned if {
+	accounts.allow_read_account with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC001",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_read_account denied for rep with unassigned account
+test_allow_read_account_denied_unassigned if {
+	not accounts.allow_read_account with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC999",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_read_balance for user with permission
+test_allow_read_balance if {
+	accounts.allow_read_balance with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC001/balance",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_list_accounts for manager
+test_allow_list_accounts_manager if {
+	accounts.allow_list_accounts with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_list_accounts for senior representative
+test_allow_list_accounts_senior_rep if {
+	accounts.allow_list_accounts with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts",
+				"headers": {"authorization": "Bearer token-senior"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_list_accounts denied for regular representative
+test_allow_list_accounts_denied_rep if {
+	not accounts.allow_list_accounts with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_open_account for manager with checking account
+test_allow_open_account_checking if {
+	accounts.allow_open_account with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts",
+				"headers": {"authorization": "Bearer token-manager"},
+			},
+			"body": {"account_type": "checking"},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_open_account for senior rep with savings account
+test_allow_open_account_savings if {
+	accounts.allow_open_account with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts",
+				"headers": {"authorization": "Bearer token-senior"},
+			},
+			"body": {"account_type": "savings"},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_open_account denied for investment account (retail only does checking/savings)
+test_allow_open_account_denied_investment if {
+	not accounts.allow_open_account with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts",
+				"headers": {"authorization": "Bearer token-manager"},
+			},
+			"body": {"account_type": "investment"},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_open_account denied for regular representative
+test_allow_open_account_denied_rep if {
+	not accounts.allow_open_account with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts",
+				"headers": {"authorization": "Bearer token-rep"},
+			},
+			"body": {"account_type": "checking"},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_close_account for manager only
+test_allow_close_account_manager if {
+	accounts.allow_close_account with input as {
+		"request": {
+			"http": {
+				"method": "DELETE",
+				"path": "/accounts/ACC123",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_close_account denied for senior representative
+test_allow_close_account_denied_senior_rep if {
+	not accounts.allow_close_account with input as {
+		"request": {
+			"http": {
+				"method": "DELETE",
+				"path": "/accounts/ACC123",
+				"headers": {"authorization": "Bearer token-senior"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_update_account_status for manager
+test_allow_update_account_status_manager if {
+	accounts.allow_update_account_status with input as {
+		"request": {
+			"http": {
+				"method": "PATCH",
+				"path": "/accounts/ACC123/status",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_update_account_status for senior representative
+test_allow_update_account_status_senior_rep if {
+	accounts.allow_update_account_status with input as {
+		"request": {
+			"http": {
+				"method": "PATCH",
+				"path": "/accounts/ACC123/status",
+				"headers": {"authorization": "Bearer token-senior"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_update_account_status denied for regular representative
+test_allow_update_account_status_denied_rep if {
+	not accounts.allow_update_account_status with input as {
+		"request": {
+			"http": {
+				"method": "PATCH",
+				"path": "/accounts/ACC123/status",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# =============================================================================
+# RETAIL CUSTOMER TESTS
+# =============================================================================
+
+# Test: customer can access their own account
+test_customer_access_own_account if {
+	accounts.account_access_allowed(
+		{"role": "retail_customer", "sub": "alice.consumer"},
+		"ACC-R001",
+	) with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer cannot access another customer's account
+test_customer_denied_other_account if {
+	not accounts.account_access_allowed(
+		{"role": "retail_customer", "sub": "alice.consumer"},
+		"ACC-R003",
+	) with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer can read their own account details
+test_customer_read_own_account if {
+	accounts.allow_read_account with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R001",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer denied reading another customer's account
+test_customer_denied_read_other_account if {
+	not accounts.allow_read_account with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R003",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer can read their own balance
+test_customer_read_own_balance if {
+	accounts.allow_read_balance with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R001/balance",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: premium customer can access their accounts
+test_premium_customer_access_account if {
+	accounts.allow_read_account with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R003",
+				"headers": {"authorization": "Bearer token-bob"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: joint account holder can access shared account
+test_joint_account_access if {
+	accounts.allow_read_account with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R001",
+				"headers": {"authorization": "Bearer token-carol"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: joint account holder can also access their own account
+test_joint_account_holder_own_account if {
+	accounts.allow_read_account with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R006",
+				"headers": {"authorization": "Bearer token-carol"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: inactive customer denied access
+test_inactive_customer_denied if {
+	not accounts.allow_read_account with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R007",
+				"headers": {"authorization": "Bearer token-dan"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer cannot list all accounts (internal only)
+test_customer_denied_list_accounts if {
+	not accounts.allow_list_accounts with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: customer cannot open new accounts (internal only)
+test_customer_denied_open_account if {
+	not accounts.allow_open_account with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts",
+				"headers": {"authorization": "Bearer token-alice"},
+			},
+			"body": {"account_type": "checking"},
+		}
+	} with data.users as mock_users
+}
+
+# Test: customer cannot close accounts (internal only)
+test_customer_denied_close_account if {
+	not accounts.allow_close_account with input as {
+		"request": {
+			"http": {
+				"method": "DELETE",
+				"path": "/accounts/ACC-R001",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: customer cannot update account status (internal only)
+test_customer_denied_update_status if {
+	not accounts.allow_update_account_status with input as {
+		"request": {
+			"http": {
+				"method": "PATCH",
+				"path": "/accounts/ACC-R001/status",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+}

--- a/infra/opa/policies/retail/retail_api/authentication_test.rego
+++ b/infra/opa/policies/retail/retail_api/authentication_test.rego
@@ -1,0 +1,229 @@
+package retail.retail_api.authentication_test
+
+import rego.v1
+
+import data.retail.retail_api.authentication
+
+# Mock user data for testing (internal employees and external customers)
+mock_users := {
+	"jsmith": {
+		"token": "valid-token-jsmith",
+		"role": "senior_representative",
+		"permissions": ["accounts:read", "transactions:read"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"inactive_user": {
+		"token": "valid-token-inactive",
+		"role": "representative",
+		"permissions": ["accounts:read"],
+		"department": "retail",
+		"active": false,
+		"exp": 9999999999,
+	},
+	"alice.consumer": {
+		"token": "token-alice",
+		"role": "retail_customer",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "transactions:create", "credit:create", "debit:create", "terms:read"],
+		"department": "retail_banking",
+		"active": true,
+		"exp": 9999999999,
+		"customer_tier": "standard",
+	},
+	"dan.inactive": {
+		"token": "token-dan",
+		"role": "retail_customer",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "terms:read"],
+		"department": "retail_banking",
+		"active": false,
+		"exp": 9999999999,
+		"customer_tier": "standard",
+	},
+}
+
+# Test: extract_token extracts bearer token correctly
+test_extract_token_valid if {
+	token := authentication.extract_token with input as {
+		"request": {"http": {"headers": {"authorization": "Bearer my-test-token"}}}
+	}
+	token == "my-test-token"
+}
+
+# Test: extract_token fails without Bearer prefix
+test_extract_token_no_bearer if {
+	not authentication.extract_token with input as {
+		"request": {"http": {"headers": {"authorization": "Basic credentials"}}}
+	}
+}
+
+# Test: extract_token fails with missing header
+test_extract_token_missing_header if {
+	not authentication.extract_token with input as {
+		"request": {"http": {"headers": {}}}
+	}
+}
+
+# Test: valid_token accepts non-empty token
+test_valid_token_non_empty if {
+	authentication.valid_token("some-token")
+}
+
+# Test: valid_token rejects empty token
+test_valid_token_empty if {
+	not authentication.valid_token("")
+}
+
+# Test: claims extracts user claims from token
+test_claims_valid_user if {
+	user_claims := authentication.claims("valid-token-jsmith") with data.users as mock_users
+	user_claims.sub == "jsmith"
+	user_claims.role == "senior_representative"
+	"accounts:read" in user_claims.permissions
+}
+
+# Test: user_active returns true for active user
+test_user_active_true if {
+	authentication.user_active({"active": true})
+}
+
+# Test: user_active returns false for inactive user
+test_user_active_false if {
+	not authentication.user_active({"active": false})
+}
+
+# Test: authenticated_claims returns claims for valid active user
+test_authenticated_claims_valid if {
+	claims := authentication.authenticated_claims with input as {
+		"request": {"http": {"headers": {"authorization": "Bearer valid-token-jsmith"}}}
+	} with data.users as mock_users
+	claims.sub == "jsmith"
+	claims.active == true
+}
+
+# Test: authenticated_claims fails for inactive user
+test_authenticated_claims_inactive_user if {
+	not authentication.authenticated_claims with input as {
+		"request": {"http": {"headers": {"authorization": "Bearer valid-token-inactive"}}}
+	} with data.users as mock_users
+}
+
+# Test: allow_login permits POST to /auth/login
+test_allow_login_post if {
+	authentication.allow_login with input as {
+		"request": {"http": {"method": "POST", "path": "/auth/login"}}
+	}
+}
+
+# Test: allow_login denies GET to /auth/login
+test_allow_login_wrong_method if {
+	not authentication.allow_login with input as {
+		"request": {"http": {"method": "GET", "path": "/auth/login"}}
+	}
+}
+
+# Test: allow_login denies POST to wrong path
+test_allow_login_wrong_path if {
+	not authentication.allow_login with input as {
+		"request": {"http": {"method": "POST", "path": "/auth/register"}}
+	}
+}
+
+# Test: allow_logout permits authenticated user
+test_allow_logout_authenticated if {
+	authentication.allow_logout with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/auth/logout",
+				"headers": {"authorization": "Bearer valid-token-jsmith"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_logout denies unauthenticated user
+test_allow_logout_unauthenticated if {
+	not authentication.allow_logout with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/auth/logout",
+				"headers": {},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_verify permits authenticated user
+test_allow_verify_authenticated if {
+	authentication.allow_verify with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/auth/verify",
+				"headers": {"authorization": "Bearer valid-token-jsmith"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_verify denies unauthenticated user
+test_allow_verify_unauthenticated if {
+	not authentication.allow_verify with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/auth/verify",
+				"headers": {},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# =============================================================================
+# RETAIL CUSTOMER AUTHENTICATION TESTS
+# =============================================================================
+
+# Test: customer can authenticate with valid token
+test_customer_authenticated_claims if {
+	claims := authentication.authenticated_claims with input as {
+		"request": {"http": {"headers": {"authorization": "Bearer token-alice"}}}
+	} with data.users as mock_users
+	claims.sub == "alice.consumer"
+	claims.role == "retail_customer"
+	claims.active == true
+}
+
+# Test: customer can logout
+test_customer_logout if {
+	authentication.allow_logout with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/auth/logout",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: customer can verify token
+test_customer_verify if {
+	authentication.allow_verify with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/auth/verify",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: inactive customer cannot authenticate
+test_inactive_customer_denied if {
+	not authentication.authenticated_claims with input as {
+		"request": {"http": {"headers": {"authorization": "Bearer token-dan"}}}
+	} with data.users as mock_users
+}

--- a/infra/opa/policies/retail/retail_api/compliance_test.rego
+++ b/infra/opa/policies/retail/retail_api/compliance_test.rego
@@ -1,0 +1,315 @@
+package retail.retail_api.compliance_test
+
+import rego.v1
+
+import data.retail.retail_api.compliance
+
+# Mock user data for testing (internal employees and external customers)
+mock_users := {
+	"manager1": {
+		"token": "token-manager",
+		"role": "manager",
+		"permissions": ["accounts:read", "admin:update"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"senior_rep": {
+		"token": "token-senior",
+		"role": "senior_representative",
+		"permissions": ["accounts:read", "transactions:read"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"rep1": {
+		"token": "token-rep",
+		"role": "representative",
+		"permissions": ["accounts:read"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"alice.consumer": {
+		"token": "token-alice",
+		"role": "retail_customer",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "transactions:create", "credit:create", "debit:create", "terms:read"],
+		"department": "retail_banking",
+		"active": true,
+		"exp": 9999999999,
+		"customer_tier": "standard",
+	},
+	"dan.inactive": {
+		"token": "token-dan",
+		"role": "retail_customer",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "terms:read"],
+		"department": "retail_banking",
+		"active": false,
+		"exp": 9999999999,
+		"customer_tier": "standard",
+	},
+}
+
+# Test: banking_hours configuration
+test_banking_hours_start if {
+	compliance.banking_hours.start == 6
+}
+
+test_banking_hours_end if {
+	compliance.banking_hours.end == 22
+}
+
+# Test: time_based_access_allowed (uses mock hour of 9)
+test_time_based_access_allowed if {
+	compliance.time_based_access_allowed
+}
+
+# Test: overdraft configuration
+test_overdraft_fee if {
+	compliance.overdraft_fee == 35
+}
+
+test_overdraft_daily_max if {
+	compliance.overdraft_daily_max == 6
+}
+
+# Test: Regulation D savings withdrawal limit
+test_reg_d_monthly_limit if {
+	compliance.reg_d_monthly_limit == 6
+}
+
+# Test: FDIC insurance configuration
+test_fdic_insured if {
+	compliance.fdic_insured == true
+}
+
+test_fdic_limit if {
+	compliance.fdic_limit == 250000
+}
+
+# Test: fraud_monitoring configuration
+test_fraud_monitoring_enabled if {
+	compliance.fraud_monitoring.enabled == true
+}
+
+test_fraud_monitoring_threshold if {
+	compliance.fraud_monitoring.transaction_threshold == 1000
+}
+
+test_fraud_monitoring_geographic_check if {
+	compliance.fraud_monitoring.geographic_check == true
+}
+
+test_fraud_monitoring_velocity_check if {
+	compliance.fraud_monitoring.velocity_check == true
+}
+
+# Test: suspicious_transaction detection for high amounts
+test_suspicious_transaction_high_amount if {
+	compliance.suspicious_transaction with input as {
+		"request": {"body": {"amount": 5000}}
+	}
+}
+
+# Test: suspicious_transaction not triggered for low amounts
+test_suspicious_transaction_low_amount if {
+	not compliance.suspicious_transaction with input as {
+		"request": {"body": {"amount": 500}}
+	}
+}
+
+# Test: allow_read_terms for authenticated user
+test_allow_read_terms_authenticated if {
+	compliance.allow_read_terms with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/terms/privacy",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_read_terms denied for unauthenticated user
+test_allow_read_terms_unauthenticated if {
+	not compliance.allow_read_terms with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/terms/privacy",
+				"headers": {},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_fraud_review for manager
+test_allow_fraud_review_manager if {
+	compliance.allow_fraud_review with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/fraud/alerts",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_fraud_review for senior representative
+test_allow_fraud_review_senior_rep if {
+	compliance.allow_fraud_review with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/fraud/alerts/123",
+				"headers": {"authorization": "Bearer token-senior"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_fraud_review denied for regular representative
+test_allow_fraud_review_denied_rep if {
+	not compliance.allow_fraud_review with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/fraud/alerts",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_fraud_update for manager with admin:update permission
+test_allow_fraud_update_manager if {
+	compliance.allow_fraud_update with input as {
+		"request": {
+			"http": {
+				"method": "PATCH",
+				"path": "/fraud/cases/CASE001",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_fraud_update denied for senior representative
+test_allow_fraud_update_denied_senior_rep if {
+	not compliance.allow_fraud_update with input as {
+		"request": {
+			"http": {
+				"method": "PATCH",
+				"path": "/fraud/cases/CASE001",
+				"headers": {"authorization": "Bearer token-senior"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_fraud_update denied for wrong HTTP method
+test_allow_fraud_update_wrong_method if {
+	not compliance.allow_fraud_update with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/fraud/cases/CASE001",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: log_decision produces correct structure
+test_log_decision_structure if {
+	log := compliance.log_decision with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC123",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+	log.user == "manager1"
+	log.role == "manager"
+	log.resource == "/accounts/ACC123"
+	log.action == "GET"
+	log.organization == "retail"
+	log.system == "retail_api"
+}
+
+# =============================================================================
+# RETAIL CUSTOMER COMPLIANCE TESTS
+# =============================================================================
+
+# Test: customer can read terms and policies
+test_customer_read_terms if {
+	compliance.allow_read_terms with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/terms/privacy",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: customer cannot access fraud review (internal only)
+test_customer_denied_fraud_review if {
+	not compliance.allow_fraud_review with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/fraud/alerts",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: customer cannot update fraud cases (internal only)
+test_customer_denied_fraud_update if {
+	not compliance.allow_fraud_update with input as {
+		"request": {
+			"http": {
+				"method": "PATCH",
+				"path": "/fraud/cases/CASE001",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: inactive customer denied reading terms
+test_inactive_customer_denied_terms if {
+	not compliance.allow_read_terms with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/terms/privacy",
+				"headers": {"authorization": "Bearer token-dan"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: log_decision captures customer activity
+test_log_decision_customer if {
+	log := compliance.log_decision with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R001",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+	log.user == "alice.consumer"
+	log.role == "retail_customer"
+	log.resource == "/accounts/ACC-R001"
+	log.action == "GET"
+}

--- a/infra/opa/policies/retail/retail_api/transactions_test.rego
+++ b/infra/opa/policies/retail/retail_api/transactions_test.rego
@@ -1,0 +1,596 @@
+package retail.retail_api.transactions_test
+
+import rego.v1
+
+import data.retail.retail_api.transactions
+
+# Mock user data for testing (internal employees and external customers)
+mock_users := {
+	"manager1": {
+		"token": "token-manager",
+		"role": "manager",
+		"permissions": ["accounts:read", "transactions:read", "transactions:create", "debit:create", "credit:create", "admin:update"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"senior_rep": {
+		"token": "token-senior",
+		"role": "senior_representative",
+		"permissions": ["accounts:read", "transactions:read", "transactions:create", "debit:create", "credit:create", "admin:update"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"rep1": {
+		"token": "token-rep",
+		"role": "representative",
+		"permissions": ["accounts:read", "transactions:read", "debit:create", "credit:create"],
+		"department": "retail",
+		"active": true,
+		"exp": 9999999999,
+	},
+	"alice.consumer": {
+		"token": "token-alice",
+		"role": "retail_customer",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "transactions:create", "credit:create", "debit:create", "terms:read"],
+		"department": "retail_banking",
+		"active": true,
+		"exp": 9999999999,
+		"customer_tier": "standard",
+	},
+	"bob.premium": {
+		"token": "token-bob",
+		"role": "retail_customer_premium",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "transactions:create", "credit:create", "debit:create", "terms:read"],
+		"department": "retail_banking",
+		"active": true,
+		"exp": 9999999999,
+		"customer_tier": "premium",
+	},
+	"dan.inactive": {
+		"token": "token-dan",
+		"role": "retail_customer",
+		"permissions": ["accounts:read", "balance:read", "transactions:read", "terms:read"],
+		"department": "retail_banking",
+		"active": false,
+		"exp": 9999999999,
+		"customer_tier": "standard",
+	},
+}
+
+# Mock user-account assignments (employees and customers)
+mock_user_accounts := {
+	"rep1": ["ACC001", "ACC002"],
+	"senior_rep": ["ACC001", "ACC003"],
+	"alice.consumer": ["ACC-R001", "ACC-R002"],
+	"bob.premium": ["ACC-R003", "ACC-R004", "ACC-R005"],
+	"dan.inactive": ["ACC-R007"],
+}
+
+# Test: retail_daily_limits configuration
+test_retail_daily_limits_atm if {
+	transactions.retail_daily_limits.atm_withdrawal == 500
+}
+
+test_retail_daily_limits_debit_card if {
+	transactions.retail_daily_limits.debit_card == 2500
+}
+
+test_retail_daily_limits_wire if {
+	transactions.retail_daily_limits.wire_transfer == 10000
+}
+
+test_retail_daily_limits_mobile_deposit if {
+	transactions.retail_daily_limits.mobile_deposit == 5000
+}
+
+# Test: allow_read_transactions for user with assigned account
+test_allow_read_transactions_assigned if {
+	transactions.allow_read_transactions with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC001/transactions",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_read_transactions for manager (any account)
+test_allow_read_transactions_manager if {
+	transactions.allow_read_transactions with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC999/transactions",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_read_transactions denied for unassigned account
+test_allow_read_transactions_denied_unassigned if {
+	not transactions.allow_read_transactions with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC999/transactions",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_debit within limits
+test_allow_debit_within_limits if {
+	transactions.allow_debit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC001/debit",
+				"headers": {"authorization": "Bearer token-rep"},
+			},
+			"body": {
+				"amount": 400,
+				"transaction_type": "atm_withdrawal",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_debit denied over limit
+test_allow_debit_over_limit if {
+	not transactions.allow_debit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC001/debit",
+				"headers": {"authorization": "Bearer token-rep"},
+			},
+			"body": {
+				"amount": 600,
+				"transaction_type": "atm_withdrawal",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_debit denied for unassigned account
+test_allow_debit_denied_unassigned if {
+	not transactions.allow_debit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC999/debit",
+				"headers": {"authorization": "Bearer token-rep"},
+			},
+			"body": {
+				"amount": 100,
+				"transaction_type": "atm_withdrawal",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_credit for assigned account
+test_allow_credit_assigned if {
+	transactions.allow_credit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC001/credit",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_credit denied for unassigned account
+test_allow_credit_denied_unassigned if {
+	not transactions.allow_credit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC999/credit",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_internal_transfer between assigned accounts (senior rep has transactions:create)
+test_allow_internal_transfer_both_assigned if {
+	transactions.allow_internal_transfer with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transfers/internal",
+				"headers": {"authorization": "Bearer token-senior"},
+			},
+			"body": {
+				"from_account_id": "ACC001",
+				"to_account_id": "ACC003",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_internal_transfer denied when source not assigned
+test_allow_internal_transfer_denied_source_unassigned if {
+	not transactions.allow_internal_transfer with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transfers/internal",
+				"headers": {"authorization": "Bearer token-rep"},
+			},
+			"body": {
+				"from_account_id": "ACC999",
+				"to_account_id": "ACC001",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_internal_transfer denied when destination not assigned
+test_allow_internal_transfer_denied_dest_unassigned if {
+	not transactions.allow_internal_transfer with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transfers/internal",
+				"headers": {"authorization": "Bearer token-rep"},
+			},
+			"body": {
+				"from_account_id": "ACC001",
+				"to_account_id": "ACC999",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: allow_internal_transfer for manager (any accounts)
+test_allow_internal_transfer_manager if {
+	transactions.allow_internal_transfer with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transfers/internal",
+				"headers": {"authorization": "Bearer token-manager"},
+			},
+			"body": {
+				"from_account_id": "ACC888",
+				"to_account_id": "ACC999",
+			},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_manual_adjustment for senior rep under $1000
+test_allow_manual_adjustment_senior_rep if {
+	transactions.allow_manual_adjustment with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/adjust",
+				"headers": {"authorization": "Bearer token-senior"},
+			},
+			"body": {"amount": 500},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_manual_adjustment denied over $1000
+test_allow_manual_adjustment_denied_over_limit if {
+	not transactions.allow_manual_adjustment with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/adjust",
+				"headers": {"authorization": "Bearer token-senior"},
+			},
+			"body": {"amount": 1500},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_manual_adjustment denied for regular rep
+test_allow_manual_adjustment_denied_rep if {
+	not transactions.allow_manual_adjustment with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/adjust",
+				"headers": {"authorization": "Bearer token-rep"},
+			},
+			"body": {"amount": 100},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_large_adjustment for manager with dual approval
+test_allow_large_adjustment_with_dual_approval if {
+	transactions.allow_large_adjustment with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/adjust",
+				"headers": {"authorization": "Bearer token-manager"},
+			},
+			"body": {
+				"amount": 10000,
+				"dual_approval_id": "APPROVAL-123",
+			},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_large_adjustment denied without dual approval
+test_allow_large_adjustment_denied_no_approval if {
+	not transactions.allow_large_adjustment with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/adjust",
+				"headers": {"authorization": "Bearer token-manager"},
+			},
+			"body": {
+				"amount": 10000,
+				"dual_approval_id": null,
+			},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_large_adjustment denied for senior rep
+test_allow_large_adjustment_denied_senior_rep if {
+	not transactions.allow_large_adjustment with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/adjust",
+				"headers": {"authorization": "Bearer token-senior"},
+			},
+			"body": {
+				"amount": 10000,
+				"dual_approval_id": "APPROVAL-123",
+			},
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_transaction_reversal for manager only
+test_allow_transaction_reversal_manager if {
+	transactions.allow_transaction_reversal with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/reverse/TXN123",
+				"headers": {"authorization": "Bearer token-manager"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_transaction_reversal denied for senior rep
+test_allow_transaction_reversal_denied_senior_rep if {
+	not transactions.allow_transaction_reversal with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/reverse/TXN123",
+				"headers": {"authorization": "Bearer token-senior"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# Test: allow_transaction_reversal denied for regular rep
+test_allow_transaction_reversal_denied_rep if {
+	not transactions.allow_transaction_reversal with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/reverse/TXN123",
+				"headers": {"authorization": "Bearer token-rep"},
+			}
+		}
+	} with data.users as mock_users
+}
+
+# =============================================================================
+# RETAIL CUSTOMER TRANSACTION TESTS
+# =============================================================================
+
+# Test: customer can read their own transactions
+test_customer_read_own_transactions if {
+	transactions.allow_read_transactions with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R001/transactions",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer cannot read another customer's transactions
+test_customer_denied_read_other_transactions if {
+	not transactions.allow_read_transactions with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R003/transactions",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer can make debit within limits
+test_customer_debit_within_limits if {
+	transactions.allow_debit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC-R001/debit",
+				"headers": {"authorization": "Bearer token-alice"},
+			},
+			"body": {
+				"amount": 400,
+				"transaction_type": "atm_withdrawal",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer denied debit over limits
+test_customer_debit_over_limits if {
+	not transactions.allow_debit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC-R001/debit",
+				"headers": {"authorization": "Bearer token-alice"},
+			},
+			"body": {
+				"amount": 600,
+				"transaction_type": "atm_withdrawal",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer can make credit (deposit) to own account
+test_customer_credit_own_account if {
+	transactions.allow_credit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC-R001/credit",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer cannot credit another customer's account
+test_customer_denied_credit_other_account if {
+	not transactions.allow_credit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC-R003/credit",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer can transfer between own accounts
+test_customer_transfer_between_own_accounts if {
+	transactions.allow_internal_transfer with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transfers/internal",
+				"headers": {"authorization": "Bearer token-alice"},
+			},
+			"body": {
+				"from_account_id": "ACC-R001",
+				"to_account_id": "ACC-R002",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer cannot transfer to another customer's account
+test_customer_denied_transfer_to_other if {
+	not transactions.allow_internal_transfer with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transfers/internal",
+				"headers": {"authorization": "Bearer token-alice"},
+			},
+			"body": {
+				"from_account_id": "ACC-R001",
+				"to_account_id": "ACC-R003",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: premium customer can read transactions
+test_premium_customer_read_transactions if {
+	transactions.allow_read_transactions with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R003/transactions",
+				"headers": {"authorization": "Bearer token-bob"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: premium customer can make larger debit card purchases
+test_premium_customer_debit_card if {
+	transactions.allow_debit with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/accounts/ACC-R003/debit",
+				"headers": {"authorization": "Bearer token-bob"},
+			},
+			"body": {
+				"amount": 2000,
+				"transaction_type": "debit_card",
+			},
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: inactive customer denied transaction access
+test_inactive_customer_denied_transactions if {
+	not transactions.allow_read_transactions with input as {
+		"request": {
+			"http": {
+				"method": "GET",
+				"path": "/accounts/ACC-R007/transactions",
+				"headers": {"authorization": "Bearer token-dan"},
+			}
+		}
+	} with data.users as mock_users with data.user_accounts as mock_user_accounts
+}
+
+# Test: customer cannot do manual adjustments (internal only)
+test_customer_denied_manual_adjustment if {
+	not transactions.allow_manual_adjustment with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/adjust",
+				"headers": {"authorization": "Bearer token-alice"},
+			},
+			"body": {"amount": 50},
+		}
+	} with data.users as mock_users
+}
+
+# Test: customer cannot reverse transactions (internal only)
+test_customer_denied_reversal if {
+	not transactions.allow_transaction_reversal with input as {
+		"request": {
+			"http": {
+				"method": "POST",
+				"path": "/transactions/reverse/TXN123",
+				"headers": {"authorization": "Bearer token-alice"},
+			}
+		}
+	} with data.users as mock_users
+}


### PR DESCRIPTION
## Summary

This PR updates the ea-financial repository to:

### 1. Update CI Workflow for Retail API
- Updated `ea-deploy.yml` to deploy the Retail API system
- Entity ID: `52bdc2ad-444f-4577-8459-62a69704eed5` (configured in EA_ENTITY_ID secret)
- Fixed policy path from `policies/**` to `infra/opa/policies/**`

### 2. Add Retail Customer Personas
New external customer personas added to `users.json`:
| Username | Role | Tier | Description |
|----------|------|------|-------------|
| `alice.consumer` | retail_customer | standard | Standard customer with 2 accounts |
| `bob.premium` | retail_customer_premium | premium | Premium customer with higher limits |
| `carol.joint` | retail_customer | standard | Customer with joint account access |
| `dan.inactive` | retail_customer | standard | Inactive customer |

New roles with daily transaction limits:
- `retail_customer`: ATM $500, debit $2,500, transfer $5,000
- `retail_customer_premium`: ATM $1,000, debit $10,000, transfer $25,000

### 3. Add Rego Tests for Retail API Policies
Created comprehensive test files (121 tests total):
- `authentication_test.rego` - Token handling, login/logout, customer auth
- `accounts_test.rego` - Account access, CRUD operations, joint accounts
- `compliance_test.rego` - Terms access, fraud review, audit logging
- `transactions_test.rego` - Debits, credits, transfers, limits

### 4. Update README
- Added CI/CD Pipeline section documenting Retail API deployment
- Added instructions for running rego tests locally with `opa test` or `eopa test`

## Testing
```bash
opa test infra/opa/policies/retail/retail_api/ -v
# PASS: 121/121
```