### PR TITLE
EA-359: Add EA Platform integration with OPA sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ e2e-junit.xml
 test-results/
 playwright-report/
 playwright/.cache/
+
+infra/certs/
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .env.test.local
 .env.production.local
 .env.local
+.env.ea
 
 # caches
 .eslintcache

--- a/infra/.env.ea.example
+++ b/infra/.env.ea.example
@@ -1,0 +1,29 @@
+# EA Platform Integration Environment Variables
+#
+# Copy this file to .env.ea and fill in the values.
+# DO NOT commit .env.ea — it contains secrets.
+#
+# To get an EA API key:
+#   1. Apply the ea-financial demo template in the EA Platform
+#   2. Run: bun run scripts/ea-financial/provision-demo-keys.ts
+#   3. Copy the printed API key here
+
+# EA Platform API key (scoped to the Retail API entity)
+EA_API_KEY=live_xxxx_replace_me
+
+# EA Platform API URL (dev environment)
+EA_PLATFORM_URL=https://api.enforceauth.dev/v1
+
+# Unique OPA instance identifier (appears in EA Platform fleet status)
+OPA_INSTANCE_ID=retail-api-local-001
+
+# S3 bucket for OPA policy bundles (must match CDK-created bucket)
+BUNDLE_BUCKET_NAME=ea-financial-policy-bundles-dev
+
+# Environment label
+ENVIRONMENT=dev
+
+# AWS credentials for S3 bundle access
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1

--- a/infra/.env.ea.example
+++ b/infra/.env.ea.example
@@ -17,13 +17,5 @@ EA_PLATFORM_URL=https://api.enforceauth.dev/v1
 # Unique OPA instance identifier (appears in EA Platform fleet status)
 OPA_INSTANCE_ID=retail-api-local-001
 
-# S3 bucket for OPA policy bundles (must match CDK-created bucket)
-BUNDLE_BUCKET_NAME=ea-financial-policy-bundles-dev
-
 # Environment label
 ENVIRONMENT=dev
-
-# AWS credentials for S3 bundle access
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_REGION=us-east-1

--- a/infra/.env.ea.example
+++ b/infra/.env.ea.example
@@ -9,6 +9,8 @@
 #   3. Copy the printed API key here
 
 # EA Platform API key (scoped to the Retail API entity)
+# SECURITY: Use a dev/sandbox-scoped key here. Never use production credentials
+# in local development. Production deployments use AWS Secrets Manager.
 EA_API_KEY=live_xxxx_replace_me
 
 # EA Platform API URL (dev environment)

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -19,11 +19,15 @@ services:
       - "--config-file=/config/opa-config.yaml"
       - "--log-level=info"
       - "--log-format=json"
+    # NOTE: EOPA uses a distroless image (no curl/wget/shell). The ideal check
+    # would be GET /health?plugins, but there's no HTTP client in the image.
+    # 'eval true' confirms the binary runs; start_period gives the HTTP server
+    # time to bind before dependent services attempt connections.
     healthcheck:
       test: ["CMD", "/ko-app/eopa", "eval", "true"]
-      interval: 30s
+      interval: 10s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     networks:
       - ea-financial-network
@@ -214,7 +218,7 @@ services:
     image: grafana/grafana:latest
     container_name: ea-financial-grafana
     ports:
-      - "3001:3000"
+      - "3002:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin123

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
     volumes:
       # Enable hot reload for development
-      - ../projects/consumer-accounts-internal-api/src:/app/src:ro
+      - ../projects/consumer-accounts-internal-api/src:/monorepo/projects/consumer-accounts-internal-api/src:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=Host(`api.ea-financial.local`)"
@@ -101,9 +101,8 @@ services:
     restart: unless-stopped
     volumes:
       # Enable hot reload for development
-      - ../projects/consumer-accounts-internal-app/src:/app/src:ro
-      - ../projects/consumer-accounts-internal-app/public:/app/public:ro
-      - /app/node_modules
+      - ../projects/consumer-accounts-internal-app/src:/monorepo/projects/consumer-accounts-internal-app/src:ro
+      - ../projects/consumer-accounts-internal-app/public:/monorepo/projects/consumer-accounts-internal-app/public:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.app.rule=Host(`ea-financial.local`)"

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   # EOPA Service
   opa:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -20,19 +20,11 @@ services:
       - "--log-level=info"
       - "--log-format=json"
     healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:8181/health",
-        ]
+      test: ["CMD", "/ko-app/eopa", "eval", "true"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 30s
     networks:
       - ea-financial-network
     restart: unless-stopped
@@ -59,7 +51,7 @@ services:
       opa:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -99,7 +91,7 @@ services:
       consumer-accounts-api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -51,7 +51,7 @@ services:
       opa:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -75,8 +75,8 @@ services:
   # Frontend App Service
   consumer-accounts-app:
     build:
-      context: ../projects/consumer-accounts-internal-app
-      dockerfile: Dockerfile.dev
+      context: ..
+      dockerfile: projects/consumer-accounts-internal-app/Dockerfile.dev
       args:
         - REACT_APP_API_URL=http://consumer-accounts-api:3001
     container_name: ea-financial-app
@@ -91,7 +91,7 @@ services:
       consumer-accounts-api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -46,8 +46,8 @@ services:
   # API Service
   consumer-accounts-api:
     build:
-      context: ../projects/consumer-accounts-internal-api
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: projects/consumer-accounts-internal-api/Dockerfile
     container_name: ea-financial-api
     ports:
       - "3001:3001"

--- a/infra/docker-compose.ea.yml
+++ b/infra/docker-compose.ea.yml
@@ -1,0 +1,29 @@
+# Docker Compose override for EA Platform integration
+#
+# Usage:
+#   docker compose -f docker-compose.dev.yml -f docker-compose.ea.yml --env-file .env.ea up
+#
+# This overlay reconfigures the EOPA sidecar to send status reports and
+# decision logs to the EA Platform API instead of logging to console.
+# The API and App containers are unchanged.
+#
+# Prerequisites:
+#   1. Apply the ea-financial demo template in the EA Platform UI
+#   2. Provision an API key for the Retail API entity (see ea repo scripts)
+#   3. Copy .env.ea.example to .env.ea and fill in the values
+
+services:
+  opa:
+    environment:
+      - EA_API_KEY=${EA_API_KEY}
+      - EA_PLATFORM_URL=${EA_PLATFORM_URL:-https://api.enforceauth.dev/v1}
+      - OPA_INSTANCE_ID=${OPA_INSTANCE_ID:-retail-api-local-001}
+      - BUNDLE_BUCKET_NAME=${BUNDLE_BUCKET_NAME:-ea-financial-policy-bundles-dev}
+      - ENVIRONMENT=${ENVIRONMENT:-dev}
+    command:
+      - "run"
+      - "--server"
+      - "--addr=0.0.0.0:8181"
+      - "--config-file=/config/opa-config-ea.yaml"
+      - "--log-level=info"
+      - "--log-format=json"

--- a/infra/docker-compose.ea.yml
+++ b/infra/docker-compose.ea.yml
@@ -32,11 +32,5 @@ services:
     volumes:
       - ./opa/policies:/policies:ro
       - ./opa/data:/data:ro
-    # Override healthcheck: EOPA distroless image has no wget/curl.
-    # Use the OPA binary to eval a trivial query, proving the server is alive.
-    healthcheck:
-      test: ["CMD", "/ko-app/eopa", "eval", "true"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+    # Healthcheck inherited from docker-compose.dev.yml (eval true + start_period).
+    # EOPA distroless image has no curl/wget; see base file for details.

--- a/infra/docker-compose.ea.yml
+++ b/infra/docker-compose.ea.yml
@@ -1,11 +1,11 @@
 # Docker Compose override for EA Platform integration
 #
 # Usage:
-#   docker compose -f docker-compose.dev.yml -f docker-compose.ea.yml --env-file .env.ea up
+#   docker compose -f docker-compose.dev.yml -f docker-compose.ea.yml --env-file .env.ea up opa consumer-accounts-api consumer-accounts-app
 #
 # This overlay reconfigures the EOPA sidecar to send status reports and
 # decision logs to the EA Platform API instead of logging to console.
-# The API and App containers are unchanged.
+# Policies are loaded from disk (baked into the image), not S3 bundles.
 #
 # Prerequisites:
 #   1. Apply the ea-financial demo template in the EA Platform UI
@@ -18,7 +18,6 @@ services:
       - EA_API_KEY=${EA_API_KEY}
       - EA_PLATFORM_URL=${EA_PLATFORM_URL:-https://api.enforceauth.dev/v1}
       - OPA_INSTANCE_ID=${OPA_INSTANCE_ID:-retail-api-local-001}
-      - BUNDLE_BUCKET_NAME=${BUNDLE_BUCKET_NAME:-ea-financial-policy-bundles-dev}
       - ENVIRONMENT=${ENVIRONMENT:-dev}
     command:
       - "run"
@@ -27,3 +26,8 @@ services:
       - "--config-file=/config/opa-config-ea.yaml"
       - "--log-level=info"
       - "--log-format=json"
+      - "/policies"
+      - "/data"
+    volumes:
+      - ../infra/opa/policies:/policies:ro
+      - ../infra/opa/data:/data:ro

--- a/infra/docker-compose.ea.yml
+++ b/infra/docker-compose.ea.yml
@@ -30,8 +30,8 @@ services:
       - "/policies"
       - "/data"
     volumes:
-      - ../infra/opa/policies:/policies:ro
-      - ../infra/opa/data:/data:ro
+      - ./opa/policies:/policies:ro
+      - ./opa/data:/data:ro
     # Override healthcheck: EOPA distroless image has no wget/curl.
     # Use the OPA binary to eval a trivial query, proving the server is alive.
     healthcheck:

--- a/infra/docker-compose.ea.yml
+++ b/infra/docker-compose.ea.yml
@@ -5,7 +5,7 @@
 #
 # This overlay reconfigures the EOPA sidecar to send status reports and
 # decision logs to the EA Platform API instead of logging to console.
-# Policies are loaded from disk (baked into the image), not S3 bundles.
+# Policies are loaded from disk (mounted volumes), not S3 bundles.
 #
 # Prerequisites:
 #   1. Apply the ea-financial demo template in the EA Platform UI
@@ -24,6 +24,7 @@ services:
       - "--server"
       - "--addr=0.0.0.0:8181"
       - "--config-file=/config/opa-config-ea.yaml"
+      - "--set=labels.id=${OPA_INSTANCE_ID:-retail-api-local-001}"
       - "--log-level=info"
       - "--log-format=json"
       - "/policies"
@@ -31,3 +32,11 @@ services:
     volumes:
       - ../infra/opa/policies:/policies:ro
       - ../infra/opa/data:/data:ro
+    # Override healthcheck: EOPA distroless image has no wget/curl.
+    # Use the OPA binary to eval a trivial query, proving the server is alive.
+    healthcheck:
+      test: ["CMD", "/ko-app/eopa", "eval", "true"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/infra/opa/config/opa-config-ea.yaml
+++ b/infra/opa/config/opa-config-ea.yaml
@@ -39,7 +39,7 @@ plugins:
 
 decision_logs:
   service: enforceauth
-  resource: /v1/decisions/logs
+  resource: decisions/logs
   reporting:
     min_delay_seconds: 5
     max_delay_seconds: 10

--- a/infra/opa/config/opa-config-ea.yaml
+++ b/infra/opa/config/opa-config-ea.yaml
@@ -8,7 +8,8 @@
 # Requires env vars:
 #   EA_API_KEY          - API key from EA Platform (scoped to entity)
 #   EA_PLATFORM_URL     - EA Platform API base URL (e.g. https://api.enforceauth.dev/v1)
-#   OPA_INSTANCE_ID     - Unique instance identifier (becomes pdp_instance_id)
+#   OPA_INSTANCE_ID     - Stable instance name (EOPA overrides labels.id with a random UUID,
+#                        so labels.instance_name is used as pdp_instance_id instead)
 #   ENVIRONMENT         - Environment label (dev, staging, prod)
 
 services:
@@ -20,6 +21,7 @@ services:
 
 labels:
   id: "${OPA_INSTANCE_ID}"
+  instance_name: "${OPA_INSTANCE_ID}"
   version: "1.0.0"
   environment: "${ENVIRONMENT}"
 

--- a/infra/opa/config/opa-config-ea.yaml
+++ b/infra/opa/config/opa-config-ea.yaml
@@ -2,19 +2,16 @@
 # Used by: docker-compose.ea.yml overlay, ECS/Fargate deployments
 #
 # Sends status reports and decision logs to the EA Platform API
-# instead of logging to console. Requires env vars:
+# instead of logging to console. Policies are loaded from disk
+# (baked into Docker image), not from S3 bundles.
+#
+# Requires env vars:
 #   EA_API_KEY          - API key from EA Platform (scoped to entity)
 #   EA_PLATFORM_URL     - EA Platform API base URL (e.g. https://api.enforceauth.dev/v1)
 #   OPA_INSTANCE_ID     - Unique instance identifier (becomes pdp_instance_id)
-#   BUNDLE_BUCKET_NAME  - S3 bucket for policy bundles
 #   ENVIRONMENT         - Environment label (dev, staging, prod)
 
 services:
-  s3:
-    url: https://s3.us-east-1.amazonaws.com
-    credentials:
-      s3_signing:
-        environment_credentials: {}
   enforceauth:
     url: "${EA_PLATFORM_URL}"
     credentials:
@@ -47,14 +44,6 @@ server:
   encoding:
     gzip:
       min_length: 1024
-
-bundles:
-  ea-financial:
-    resource: "${BUNDLE_BUCKET_NAME}/policies/ea-financial/bundle.tar.gz"
-    service: s3
-    polling:
-      min_delay_seconds: 10
-      max_delay_seconds: 20
 
 # Configure metrics
 metrics:

--- a/infra/opa/config/opa-config-ea.yaml
+++ b/infra/opa/config/opa-config-ea.yaml
@@ -28,7 +28,7 @@ labels:
 plugins:
   envoy_ext_authz_grpc:
     addr: :9191
-    query: data.envoy.authz.allow
+    query: data.main.allow
 
 decision_logs:
   service: enforceauth
@@ -64,7 +64,7 @@ metrics:
         - 10
 
 # Default decision
-default_decision: "/v1/data/ea_financial/authz/allow"
+default_decision: "/v1/data/main/allow"
 
 # Default authorization query
-default_authorization_decision: "/v1/data/ea_financial/authz/allow"
+default_authorization_decision: "/v1/data/main/allow"

--- a/infra/opa/config/opa-config-ea.yaml
+++ b/infra/opa/config/opa-config-ea.yaml
@@ -11,6 +11,13 @@
 #   OPA_INSTANCE_ID     - Stable instance name (EOPA overrides labels.id with a random UUID,
 #                        so labels.instance_name is used as pdp_instance_id instead)
 #   ENVIRONMENT         - Environment label (dev, staging, prod)
+#
+# SECURITY:
+#   - OPA interpolates env vars at startup; resolved values are NOT logged.
+#   - Keep log-level at 'info' or above — 'debug' may expose sensitive config.
+#   - For local dev, use sandbox-scoped API keys only.
+#   - Production (ECS/Fargate) injects secrets via AWS Secrets Manager,
+#     not env vars, ensuring credentials never appear in task metadata or logs.
 
 services:
   enforceauth:

--- a/infra/opa/config/opa-config-ea.yaml
+++ b/infra/opa/config/opa-config-ea.yaml
@@ -14,9 +14,8 @@
 services:
   enforceauth:
     url: "${EA_PLATFORM_URL}"
-    credentials:
-      bearer:
-        token: "${EA_API_KEY}"
+    headers:
+      X-Api-Key: "${EA_API_KEY}"
     response_header_timeout_seconds: 10
 
 labels:

--- a/infra/opa/config/opa-config-ea.yaml
+++ b/infra/opa/config/opa-config-ea.yaml
@@ -1,0 +1,80 @@
+# OPA Configuration for EA Platform Integration
+# Used by: docker-compose.ea.yml overlay, ECS/Fargate deployments
+#
+# Sends status reports and decision logs to the EA Platform API
+# instead of logging to console. Requires env vars:
+#   EA_API_KEY          - API key from EA Platform (scoped to entity)
+#   EA_PLATFORM_URL     - EA Platform API base URL (e.g. https://api.enforceauth.dev/v1)
+#   OPA_INSTANCE_ID     - Unique instance identifier (becomes pdp_instance_id)
+#   BUNDLE_BUCKET_NAME  - S3 bucket for policy bundles
+#   ENVIRONMENT         - Environment label (dev, staging, prod)
+
+services:
+  s3:
+    url: https://s3.us-east-1.amazonaws.com
+    credentials:
+      s3_signing:
+        environment_credentials: {}
+  enforceauth:
+    url: "${EA_PLATFORM_URL}"
+    credentials:
+      bearer:
+        token: "${EA_API_KEY}"
+    response_header_timeout_seconds: 10
+
+labels:
+  id: "${OPA_INSTANCE_ID}"
+  version: "1.0.0"
+  environment: "${ENVIRONMENT}"
+
+plugins:
+  envoy_ext_authz_grpc:
+    addr: :9191
+    query: data.envoy.authz.allow
+
+decision_logs:
+  service: enforceauth
+  resource: /v1/decisions/logs
+  reporting:
+    min_delay_seconds: 5
+    max_delay_seconds: 10
+
+status:
+  service: enforceauth
+  prometheus: true
+
+server:
+  encoding:
+    gzip:
+      min_length: 1024
+
+bundles:
+  ea-financial:
+    resource: "${BUNDLE_BUCKET_NAME}/policies/ea-financial/bundle.tar.gz"
+    service: s3
+    polling:
+      min_delay_seconds: 10
+      max_delay_seconds: 20
+
+# Configure metrics
+metrics:
+  prometheus:
+    http_request_duration_seconds:
+      buckets:
+        - 0.005
+        - 0.01
+        - 0.025
+        - 0.05
+        - 0.1
+        - 0.25
+        - 0.5
+        - 1
+        - 2.5
+        - 5
+        - 10
+
+# Default decision
+default_decision: "/v1/data/ea_financial/authz/allow"
+
+# Default authorization query
+default_authorization_decision: "/v1/data/ea_financial/authz/allow"

--- a/projects/consumer-accounts-internal-api/Dockerfile
+++ b/projects/consumer-accounts-internal-api/Dockerfile
@@ -1,5 +1,5 @@
 # Use Bun base image
-FROM oven/bun:1.2-alpine
+FROM oven/bun:1.3-alpine
 
 # Set working directory to monorepo root
 WORKDIR /monorepo

--- a/projects/consumer-accounts-internal-api/Dockerfile
+++ b/projects/consumer-accounts-internal-api/Dockerfile
@@ -1,5 +1,5 @@
 # Use Bun base image
-FROM oven/bun:1.3-alpine
+FROM oven/bun:1.3.9-alpine
 
 # Set working directory to monorepo root
 WORKDIR /monorepo

--- a/projects/consumer-accounts-internal-app/.dockerignore
+++ b/projects/consumer-accounts-internal-app/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/projects/consumer-accounts-internal-app/Dockerfile.dev
+++ b/projects/consumer-accounts-internal-app/Dockerfile.dev
@@ -1,20 +1,30 @@
 # Development Dockerfile for React App
-FROM oven/bun:1.2-alpine
+FROM oven/bun:1.3-alpine
 
-# Set working directory
-WORKDIR /app
+# Set working directory to monorepo root
+WORKDIR /monorepo
 
 # Install curl for healthcheck
 RUN apk add --no-cache curl
 
-# Copy package file
-COPY package.json ./
+# Copy root package files
+COPY package.json bun.lock ./
 
-# Install dependencies
-RUN bun install
+# Copy workspace package files
+COPY projects/consumer-accounts-internal-app/package.json ./projects/consumer-accounts-internal-app/
+COPY projects/consumer-accounts-internal-api/package.json ./projects/consumer-accounts-internal-api/
 
-# Copy source code
-COPY . .
+# Install dependencies (respects workspace)
+RUN bun install --frozen-lockfile
+
+# Set working directory to app project
+WORKDIR /monorepo/projects/consumer-accounts-internal-app
+
+# Copy app source code
+COPY projects/consumer-accounts-internal-app ./
+
+# Use non-root user (provided by oven/bun image)
+USER bun
 
 # Expose port
 EXPOSE 3000

--- a/projects/consumer-accounts-internal-app/Dockerfile.dev
+++ b/projects/consumer-accounts-internal-app/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Development Dockerfile for React App
-FROM oven/bun:1.3-alpine
+FROM oven/bun:1.3.9-alpine
 
 # Set working directory to monorepo root
 WORKDIR /monorepo

--- a/projects/consumer-accounts-internal-app/Dockerfile.dev
+++ b/projects/consumer-accounts-internal-app/Dockerfile.dev
@@ -1,32 +1,20 @@
 # Development Dockerfile for React App
-FROM node:18-alpine
+FROM oven/bun:1.2-alpine
 
 # Set working directory
 WORKDIR /app
 
-# Install development dependencies
-RUN apk add --no-cache \
-    git \
-    curl
+# Install curl for healthcheck
+RUN apk add --no-cache curl
 
-# Copy package files
-COPY package*.json ./
+# Copy package file
+COPY package.json ./
 
-# Install all dependencies (including dev dependencies)
-RUN npm ci
+# Install dependencies
+RUN bun install
 
 # Copy source code
 COPY . .
-
-# Create non-root user
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S reactjs -u 1001
-
-# Change ownership of the app directory
-RUN chown -R reactjs:nodejs /app
-
-# Switch to non-root user
-USER reactjs
 
 # Expose port
 EXPOSE 3000
@@ -36,4 +24,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:3000 || exit 1
 
 # Start development server with hot reload
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "3000"]
+CMD ["bun", "run", "dev", "--", "--host", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
## Summary

Add EA Platform integration configuration for the OPA sidecar, along with several deployment fixes.

## Changes

- **feat(EA-359):** Add EA Platform integration config for OPA sidecar (docker-compose, OPA config, env example)
- **fix:** Correct API build context to repo root
- **fix:** Use bun instead of npm in app Dockerfile.dev
- **chore:** Remove obsolete `version` attribute from docker-compose
- **fix:** Add .dockerignore for app to exclude node_modules
- **fix(EA-359):** Load policies from disk instead of S3 bundles
- **fix(EA-359):** Use X-Api-Key header instead of Bearer token
- **fix(EA-359):** Fix healthchecks and add stable instance_name label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added EA Platform integration infra, an example non-sensitive env template, and updated ignored env patterns.
  * Added a Compose override for EA integration; refined local Compose healthchecks, service build contexts, and volume mounts.
  * Added Docker ignore patterns to speed builds and reduce image context.

* **New Features**
  * Enabled EA reporting/logging and Prometheus metrics for policy decisions.
  * Upgraded dev runtime/tooling and switched package manager to improve local developer workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->